### PR TITLE
docs: fix systemd code block formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ pm2 restart argo-service
 ```bash
 # 创建服务文件
 sudo nano /etc/systemd/system/nodejs-argo.service
-
 ```
+
+```ini
 [Unit]
 Description=Node.js Argo Service
 After=network.target
@@ -176,6 +177,7 @@ RestartSec=10
 WantedBy=multi-user.target
 ```
 
+```bash
 # 启动服务
 sudo systemctl start nodejs-argo
 sudo systemctl enable nodejs-argo


### PR DESCRIPTION
### 修复内容

修复 README 中「使用systemd（Linux系统服务）」一节的 Markdown 代码块闭合错误。

### 问题原因

原代码块中 `sudo nano ...` 之后的反引号提前结束了 `bash` 代码块，导致 `[Unit]`、`[Service]`、`[Install]` 等 systemd 配置内容散落在代码块外，在 GitHub 页面上渲染错乱。

### 修复方式

- 将 `sudo nano ...` 单独放入 `bash` 代码块，并正确闭合
- 将 systemd 服务配置放入独立的 `ini` 代码块
- 启动命令放入独立的 `bash` 代码块

### 效果

systemd 配置现在能完整、清晰地展示，方便用户直接参考复制。

Fixes #278